### PR TITLE
[CI/CD] Add Coverage reports to SonarCloud

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,7 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
-          pytest --cov-report=xml
+          pytest --cov-report=xml:coverage.xml
 
       - name: Upload backend coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,7 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
-          pytest --cov-report xml:coverage.xml
+          pytest --cov-report xml:coverage.xml --cov=./mapengine/tests/
 
       - name: Upload backend coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,7 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
-          pytest --cov=. --cov-report=xml --cov-report=term
+          pytest --cov=. --cov-report=xml
 
   frontend-check:
     runs-on: ubuntu-latest
@@ -116,6 +116,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v5

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -110,6 +110,12 @@ jobs:
           cd ccg_frontend/ccg_mobile
           npm run test --coverage
 
+      - name: Upload frontend coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: ccg_frontend/ccg_mobile/coverage/lcov.info
+
   sonarcloud-scan:
     runs-on: ubuntu-latest
     needs: [backend-check, frontend-check]
@@ -118,6 +124,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download frontend coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-coverage
+          path: ccg_frontend/ccg_mobile/coverage
 
       - name: Run SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@v5

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -60,7 +60,7 @@ jobs:
             sleep 3
           done
           echo "PostGIS is ready!"
-      
+
       - name: Run backend tests
         env:
           SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
@@ -79,7 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
-          pytest
+          pytest --cov=. --cov-report=xml --cov-report=term
 
   frontend-check:
     runs-on: ubuntu-latest
@@ -95,7 +95,7 @@ jobs:
           cd ccg_frontend/ccg_mobile
           npm install -g expo-cli
           npm install --legacy-peer-deps
-          npm run test
+          npm run test --coverage
 
       - name: Run ESLint
         run: |

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -104,3 +104,15 @@ jobs:
           npm install eslint-plugin-react@latest --save-dev
           npm install @typescript-eslint/eslint-plugin@latest --save-dev
           npx eslint .
+
+  sonarcloud-scan:
+    runs-on: ubuntu-latest
+    needs: [backend-check, frontend-check]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -95,7 +95,6 @@ jobs:
           cd ccg_frontend/ccg_mobile
           npm install -g expo-cli
           npm install --legacy-peer-deps
-          npm run test --coverage
 
       - name: Run ESLint & Prettier
         run: |
@@ -105,6 +104,11 @@ jobs:
           npm install @typescript-eslint/eslint-plugin@latest --save-dev
           npx eslint .
           npm run format:check
+
+      - name: Run frontend tests
+        run: |
+          cd ccg_frontend/ccg_mobile
+          npm run test --coverage
 
   sonarcloud-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,7 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
-          pytest --cov=. --cov-report=xml
+          pytest --cov-report=xml
 
   frontend-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,6 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
+          pip install pytest-cov
           pytest --cov-report=xml:coverage.xml
 
       - name: Upload backend coverage report

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,8 +79,7 @@ jobs:
           conda activate myenv
           python manage.py makemigrations
           python manage.py migrate
-          pip install pytest-cov
-          pytest --cov-report=xml:coverage.xml
+          pytest --cov-report xml:coverage.xml
 
       - name: Upload backend coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -81,6 +81,12 @@ jobs:
           python manage.py migrate
           pytest --cov-report=xml
 
+      - name: Upload backend coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: ccg_backend/coverage.xml
+
   frontend-check:
     runs-on: ubuntu-latest
     steps:
@@ -124,6 +130,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Download backend coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-coverage
+          path: ccg_backend
 
       - name: Download frontend coverage report
         uses: actions/download-artifact@v4

--- a/ccg_frontend/ccg_mobile/package.json
+++ b/ccg_frontend/ccg_mobile/package.json
@@ -12,6 +12,12 @@
   },
   "jest": {
     "preset": "jest-expo",
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": [
+      "lcov",
+      "text"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)"
     ],

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,6 @@
 # SonarCloud Project Details
+sonar.projectKey=kaoutarell_Concordia_Campus_Guide
+sonar.organization=kaoutarell
 sonar.sources=.
 sonar.exclusions=**/node_modules/**, **/__tests__/**, **/*.spec.js
 sonar.tests=.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,18 @@
+# SonarCloud Project Details
+sonar.sources=.
+sonar.exclusions=**/node_modules/**, **/__tests__/**, **/*.spec.js
+sonar.tests=.
+sonar.test.inclusions=**/*.test.js, **/*.spec.js, **/tests/**/*.py
+
+# Specify Python Version
+sonar.python.version=3.10
+
+# Python Coverage
+sonar.python.coverage.reportPaths=ccg_backend/coverage.xml
+
+# React Native Coverage
+sonar.javascript.lcov.reportPaths=ccg_frontend/ccg_mobile/coverage/lcov.info
+
+# Other Settings
+sonar.sourceEncoding=UTF-8
+sonar.coverage.exclusions=**/*.test.js, **/*.spec.js, **/tests/**


### PR DESCRIPTION
Issue #177 

The coverage reports generated by PyTest and Jest will now be uploaded as pipeline artifacts and used by SonarCloud where it can be displayed.