### PR TITLE
Fix: Error message after clicking on a POI

### DIFF
--- a/ccg_frontend/ccg_mobile/api/dataService.js
+++ b/ccg_frontend/ccg_mobile/api/dataService.js
@@ -36,7 +36,11 @@ export const getPointOfInterests = async (category = null, campus = null, long =
   if (long && lat) {
     endpoint += category || campus ? `&long=${long}&lat=${lat}` : `?long=${long}&lat=${lat}`;
   }
-  return await fetchDataByEndpoint(endpoint);
+  let data = await fetchDataByEndpoint(endpoint);
+  data = data.map(poi => {
+    return { ...poi, building_code: "" };
+  });
+  return data;
 };
 
 export const getIndoorDirections = async (profile, start, destination) => {


### PR DESCRIPTION
How I fixed it?

- Added attribute `building_code` as an empty string to all POI

Related issue: #211 