### PR TITLE
Google signin feature toggle

### DIFF
--- a/ccg_frontend/ccg_mobile/__tests__/SideBar.test.js
+++ b/ccg_frontend/ccg_mobile/__tests__/SideBar.test.js
@@ -70,11 +70,17 @@ describe("Sidebar", () => {
 
   // Test to check if the Google Calendar button triggers the correct navigation
   it("navigates to Calendar when Google Calendar button is pressed", () => {
+    // Mock environment variable
+    process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES = "false";
+
     const { getByText } = render(component);
-    const calendarButton = getByText("Google Calendar");
+    const calendarButton = getByText("📅 Events");
 
     fireEvent.press(calendarButton);
     expect(mockNavigate).toHaveBeenCalledWith("Calendar");
+
+    // Cleanup: Reset process.env after the test
+    delete process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES;
   });
 
   // Test to check if the "Navigate" button triggers the correct navigation

--- a/ccg_frontend/ccg_mobile/components/map-screen-ui/sections/SideBar.js
+++ b/ccg_frontend/ccg_mobile/components/map-screen-ui/sections/SideBar.js
@@ -20,9 +20,12 @@ function Sidebar() {
           <Text style={styles.menuItem}>🏛 Explore All Buildings</Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={styles.menuButton} onPress={() => navigation.navigate("Calendar")}>
-          <Text style={styles.menuItem}>Google Calendar</Text>
-        </TouchableOpacity>
+        {(process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES == null ||
+          process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES === "false") && (
+          <TouchableOpacity style={styles.menuButton} onPress={() => navigation.navigate("Calendar")}>
+            <Text style={styles.menuItem}>📅 Events</Text>
+          </TouchableOpacity>
+        )}
 
         <TouchableOpacity style={styles.menuButton} onPress={() => navigation.navigate("Navigation")}>
           <Text style={styles.menuItem}>🚶‍♂️ Navigate</Text>

--- a/ccg_frontend/ccg_mobile/navigation/AppNavigator.js
+++ b/ccg_frontend/ccg_mobile/navigation/AppNavigator.js
@@ -8,12 +8,17 @@ import NavigationScreen from "../components/navigation-screen-ui/NavigationScree
 
 import Sidebar from "../components/map-screen-ui/sections/SideBar";
 import CustomNavSearch from "../components/navigation-screen-ui/CustomNavSearch";
-import CalendarScreen from "../components/calendar-screen-ui/CalendarScreen";
 import IndoorNavigationScreen from "../components/indoor-navigation-ui/IndoorNavigationScreen";
 
 let Clarity;
-if (process.env.EXPO_PUBLIC_USE_EXPO_GO == null) {
+let CalendarScreen = null;
+// Check if the environment variable is set to disable native modules. If not, require the native module.
+if (
+  process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES == null ||
+  process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES === "false"
+) {
   Clarity = require("@microsoft/react-native-clarity");
+  CalendarScreen = require("../components/calendar-screen-ui/CalendarScreen").default;
 }
 
 const Drawer = createDrawerNavigator();
@@ -26,7 +31,10 @@ const StackNavigator = () => {
       <Stack.Screen name="Home" component={HomeScreen} />
       <Stack.Screen name="Indoor" component={IndoorNavigationScreen} />
       <Stack.Screen name="Map" component={MapScreen} />
-      <Stack.Screen name="Calendar" component={CalendarScreen} />
+      {(process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES == null ||
+        process.env.EXPO_PUBLIC_DISABLE_NATIVE_MODULES === "false") && (
+        <Stack.Screen name="Calendar" component={CalendarScreen} />
+      )}
       <Stack.Screen name="Navigation" component={NavigationScreen} />
       <Stack.Screen name="Search" component={CustomNavSearch} />
     </Stack.Navigator>


### PR DESCRIPTION
# What's New?
We now have a toggle to disable native modules via an environment variable. Currently, our app uses two native modules—one for usability testing and another for Google Sign-In. By adding this toggle, we can disable both modules when needed, making it possible to run the app in Expo Go.

# How to disable native modules?
Add the following to `ccg_frontend/ccg_mobile/.env`:
```
EXPO_PUBLIC_DISABLE_NATIVE_MODULES=true
```

# What if I want to use a native build?
Just set the value to false or remove the variable from the .env file:
```
EXPO_PUBLIC_DISABLE_NATIVE_MODULES=false
```
