### PR TITLE
[CI/CD] Upload Coverge to CodeCov

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -145,3 +145,9 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ccg_backend/coverage.xml, ccg_frontend/ccg_mobile/coverage/lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
Modify the pipeline to include step to upload Jest (frontend) and PyTest (backend) coverage to CodeCov.
The PR coverage is available [here].(https://app.codecov.io/github/kaoutarell/Concordia_Campus_Guide/commit/fe40ccba0d7c732c09fba739cbab26521c2f2998)
Once the PR is merged, the main (overall) code coverage will also be available.